### PR TITLE
Add re (regex) module and allow listing of (implicit) parent directories

### DIFF
--- a/internal/scripts/export_test.go
+++ b/internal/scripts/export_test.go
@@ -1,0 +1,3 @@
+package scripts
+
+var LoadModule = loadModule

--- a/internal/scripts/re.go
+++ b/internal/scripts/re.go
@@ -1,0 +1,185 @@
+package scripts
+
+import (
+	"regexp"
+
+	"go.starlark.net/starlark"
+	"go.starlark.net/starlarkstruct"
+)
+
+var reModuleName = "re.star"
+
+var reModule = starlark.StringDict{
+	"re": &starlarkstruct.Module{
+		Name: "re",
+		Members: starlark.StringDict{
+			"compile": starlark.NewBuiltin("compile", compile),
+			"find":    starlark.NewBuiltin("find", find),
+			"findall": starlark.NewBuiltin("findall", findAll),
+			"split":   starlark.NewBuiltin("split", split),
+		},
+	},
+}
+
+func unmarshalInt(in starlark.Int) (int, error) {
+	var out int = 0
+	err := starlark.AsInt(in, &out)
+	return out, err
+}
+
+func marshalStringArray(match []string) starlark.Value {
+	if match == nil {
+		return starlark.None
+	}
+	resultArray := make([]starlark.Value, len(match))
+	for i, str := range match {
+		resultArray[i] = starlark.String(str)
+	}
+	return starlark.Tuple(resultArray)
+}
+
+func regexFind(regex *regexp.Regexp, str starlark.String) (starlark.Value, error) {
+	match := regex.FindStringSubmatch(string(str))
+	return marshalStringArray(match), nil
+}
+
+func regexFindAll(regex *regexp.Regexp, str starlark.String, limit starlark.Int) (starlark.Value, error) {
+	limitInt, err := unmarshalInt(limit)
+	if err != nil {
+		return nil, err
+	}
+	matches := regex.FindAllStringSubmatch(string(str), limitInt)
+	resultArray := make([]starlark.Value, len(matches))
+	for i, match := range matches {
+		resultArray[i] = marshalStringArray(match)
+	}
+	return starlark.NewList(resultArray), nil
+}
+
+func regexSplit(regex *regexp.Regexp, str starlark.String, limit starlark.Int) (starlark.Value, error) {
+	limitInt, err := unmarshalInt(limit)
+	if err != nil {
+		return nil, err
+	}
+	parts := regex.Split(string(str), limitInt)
+	return marshalStringArray(parts), nil
+}
+
+func compile(_ *starlark.Thread, _ *starlark.Builtin, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
+	var pattern starlark.String
+	if err := starlark.UnpackArgs("compile", args, kwargs, "pattern", &pattern); err != nil {
+		return starlark.None, err
+	}
+	return newRegex(pattern)
+}
+
+func find(_ *starlark.Thread, _ *starlark.Builtin, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
+	var pattern, str starlark.String
+	if err := starlark.UnpackArgs("find", args, kwargs, "pattern", &pattern, "string", &str); err != nil {
+		return starlark.None, err
+	}
+	regex, err := regexp.Compile(string(pattern))
+	if err != nil {
+		return nil, err
+	}
+	return regexFind(regex, str)
+}
+
+func findAll(_ *starlark.Thread, _ *starlark.Builtin, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
+	var pattern, str starlark.String
+	var limit = starlark.MakeInt(-1)
+	if err := starlark.UnpackArgs("findall", args, kwargs, "pattern", &pattern, "string", &str, "limit?", &limit); err != nil {
+		return starlark.None, err
+	}
+	regex, err := regexp.Compile(string(pattern))
+	if err != nil {
+		return nil, err
+	}
+	return regexFindAll(regex, str, limit)
+}
+
+func split(_ *starlark.Thread, _ *starlark.Builtin, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
+	var pattern, str starlark.String
+	var limit = starlark.MakeInt(-1)
+	if err := starlark.UnpackArgs("split", args, kwargs, "pattern", &pattern, "string", &str, "limit?", &limit); err != nil {
+		return starlark.None, err
+	}
+	regex, err := regexp.Compile(string(pattern))
+	if err != nil {
+		return nil, err
+	}
+	return regexSplit(regex, str, limit)
+}
+
+type Regex struct {
+	regex *regexp.Regexp
+}
+
+func newRegex(pattern starlark.String) (*Regex, error) {
+	re, err := regexp.Compile(string(pattern))
+	if err != nil {
+		return nil, err
+	}
+	return &Regex{regex: re}, nil
+}
+
+func (r *Regex) String() string {
+	return r.regex.String()
+}
+
+func (r *Regex) Type() string {
+	return "Regex"
+}
+
+func (r *Regex) Freeze() {
+}
+
+func (r *Regex) Hash() (uint32, error) {
+	return starlark.String(r.regex.String()).Hash()
+}
+
+func (r *Regex) Truth() starlark.Bool {
+	return true
+}
+
+func (r *Regex) Attr(name string) (starlark.Value, error) {
+	switch name {
+	case "find":
+		return starlark.NewBuiltin("Regex.find", r.find), nil
+	case "findall":
+		return starlark.NewBuiltin("Regex.findall", r.findAll), nil
+	case "split":
+		return starlark.NewBuiltin("Regex.split", r.split), nil
+	}
+	return nil, nil
+}
+
+func (r *Regex) AttrNames() []string {
+	return []string{"find", "findall", "split"}
+}
+
+func (r *Regex) find(_ *starlark.Thread, _ *starlark.Builtin, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
+	var str starlark.String
+	if err := starlark.UnpackArgs("Regex.find", args, kwargs, "string", &str); err != nil {
+		return starlark.None, err
+	}
+	return regexFind(r.regex, str)
+}
+
+func (r *Regex) findAll(_ *starlark.Thread, _ *starlark.Builtin, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
+	var str starlark.String
+	var limit = starlark.MakeInt(-1)
+	if err := starlark.UnpackArgs("Regex.findall", args, kwargs, "string", &str, "limit?", &limit); err != nil {
+		return starlark.None, err
+	}
+	return regexFindAll(r.regex, str, limit)
+}
+
+func (r *Regex) split(_ *starlark.Thread, _ *starlark.Builtin, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
+	var str starlark.String
+	var limit = starlark.MakeInt(-1)
+	if err := starlark.UnpackArgs("Regex.split", args, kwargs, "string", &str, "limit?", &limit); err != nil {
+		return starlark.None, err
+	}
+	return regexSplit(r.regex, str, limit)
+}

--- a/internal/scripts/scripts.go
+++ b/internal/scripts/scripts.go
@@ -23,8 +23,17 @@ type RunOptions struct {
 	Script    string
 }
 
+func loadModule(_ *starlark.Thread, module string) (starlark.StringDict, error) {
+	switch module {
+	case reModuleName:
+		return reModule, nil
+	default:
+		return nil, fmt.Errorf("no such module: %s", module)
+	}
+}
+
 func Run(opts *RunOptions) error {
-	thread := &starlark.Thread{Name: opts.Label}
+	thread := &starlark.Thread{Name: opts.Label, Load: loadModule}
 	globals, err := starlark.ExecFile(thread, opts.Label, opts.Script, opts.Namespace)
 	_ = globals
 	return err

--- a/internal/scripts/scripts_test.go
+++ b/internal/scripts/scripts_test.go
@@ -200,6 +200,26 @@ var scriptsTests = []scriptsTest{{
 		return nil
 	},
 	error: `no write: /foo/file2.txt`,
+}, {
+	summary: "Create a symlink",
+	content: map[string]string{
+		"foo/file1.txt": `data1`,
+		"bar/file2.txt": `data2`,
+	},
+	script: `
+		content.symlink("file1.txt", "/foo/file1.link.txt")
+		content.symlink("/foo/file1.txt", "/bar/file1.link.txt")
+		content.symlink("bar/", "/bar.link")
+	`,
+	result: map[string]string{
+		"/foo/":               "dir 0755",
+		"/foo/file1.txt":      "file 0644 5b41362b",
+		"/foo/file1.link.txt": "symlink file1.txt",
+		"/bar/":               "dir 0755",
+		"/bar/file1.link.txt": "symlink /foo/file1.txt",
+		"/bar/file2.txt":      "file 0644 d98cf53e",
+		"/bar.link":           "symlink bar/",
+	},
 }}
 
 func (s *S) TestScripts(c *C) {

--- a/internal/scripts/scripts_test.go
+++ b/internal/scripts/scripts_test.go
@@ -18,8 +18,8 @@ type scriptsTest struct {
 	hackdir func(c *C, dir string)
 	script  string
 	result  map[string]string
-	checkr  func(path string) error
-	checkw  func(path string) error
+	checkr  func(_ *scripts.ContentValue, path string) error
+	checkw  func(_ *scripts.ContentValue, path string) error
 	error   string
 }
 
@@ -127,7 +127,7 @@ var scriptsTests = []scriptsTest{{
 		content.write("/foo/../bar/file2.txt", "data2")
 		content.read("/foo/../bar/file2.txt")
 	`,
-	checkr: func(p string) error { return fmt.Errorf("no read: %s", p) },
+	checkr: func(_ *scripts.ContentValue, p string) error { return fmt.Errorf("no read: %s", p) },
 	error:  `no read: /bar/file2.txt`,
 }, {
 	summary: "Check writes",
@@ -138,7 +138,7 @@ var scriptsTests = []scriptsTest{{
 		content.read("/foo/../bar/file1.txt")
 		content.write("/foo/../bar/file1.txt", "data1")
 	`,
-	checkw: func(p string) error { return fmt.Errorf("no write: %s", p) },
+	checkw: func(_ *scripts.ContentValue, p string) error { return fmt.Errorf("no write: %s", p) },
 	error:  `no write: /bar/file1.txt`,
 }, {
 	summary: "Check lists",
@@ -149,7 +149,7 @@ var scriptsTests = []scriptsTest{{
 		content.write("/foo/../bar/file2.txt", "data2")
 		content.list("/foo/../bar/")
 	`,
-	checkr: func(p string) error { return fmt.Errorf("no read: %s", p) },
+	checkr: func(_ *scripts.ContentValue, p string) error { return fmt.Errorf("no read: %s", p) },
 	error:  `no read: /bar/`,
 }, {
 	summary: "Check lists",
@@ -160,7 +160,7 @@ var scriptsTests = []scriptsTest{{
 		content.write("/foo/../bar/file2.txt", "data2")
 		content.list("/foo/../bar")
 	`,
-	checkr: func(p string) error { return fmt.Errorf("no read: %s", p) },
+	checkr: func(_ *scripts.ContentValue, p string) error { return fmt.Errorf("no read: %s", p) },
 	error:  `no read: /bar/`,
 }, {
 	summary: "Check reads on symlinks",
@@ -174,7 +174,7 @@ var scriptsTests = []scriptsTest{{
 	script: `
 		content.read("/foo/file1.txt")
 	`,
-	checkr: func(p string) error {
+	checkr: func(_ *scripts.ContentValue, p string) error {
 		if p == "/foo/file2.txt" {
 			return fmt.Errorf("no read: %s", p)
 		}
@@ -193,7 +193,7 @@ var scriptsTests = []scriptsTest{{
 	script: `
 		content.write("/foo/file1.txt", "")
 	`,
-	checkw: func(p string) error {
+	checkw: func(_ *scripts.ContentValue, p string) error {
 		if p == "/foo/file2.txt" {
 			return fmt.Errorf("no write: %s", p)
 		}
@@ -243,6 +243,6 @@ func (s *S) TestScripts(c *C) {
 
 func (s *S) TestContentRelative(c *C) {
 	content := scripts.ContentValue{RootDir: "foo"}
-	_, err := content.RealPath("/bar", scripts.CheckNone)
+	_, err := content.RealPath("/bar", nil)
 	c.Assert(err, ErrorMatches, "internal error: content defined with relative root: foo")
 }

--- a/internal/scripts/testdata/re.star
+++ b/internal/scripts/testdata/re.star
@@ -1,0 +1,41 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2018 QRI, Inc.
+# Copyright (c) 2022 Canonical Ltd.
+
+load("assert.star", "assert")
+load("re.star", "re")
+
+def test_regex(fn, pattern, args, expect):
+    assert.eq(getattr(re, fn)(pattern, *args), expect)
+    assert.eq(getattr(re.compile(pattern), fn)(*args), expect)
+
+test_regex("find",
+    r"(\w*)\s*(ADD|REM|DEL|EXT|TRF)\s*(.*)\s*(NAT|INT)\s*(.*)\s*(\(\w{2}\))\s*(.*)",
+    ["EDM ADD FROM INJURED NAT Jordan BEAULIEU (DB) Western University"],
+    (
+      "EDM ADD FROM INJURED NAT Jordan BEAULIEU (DB) Western University",
+      "EDM",
+      "ADD",
+      "FROM INJURED ",
+      "NAT",
+      "Jordan BEAULIEU ",
+      "(DB)",
+      "Western University",
+    )
+)
+
+test_regex("split", r"\s+",
+    ["  foo bar   baz\tqux quux ", 5],
+    ("", "foo", "bar", "baz", "qux quux ")
+)
+
+test_regex("findall", r"\b([A-Z])\w+",
+    ["Alpha Bravo charlie DELTA Echo F Hotel"],
+    [
+        ("Alpha", "A"),
+        ("Bravo", "B"),
+        ("DELTA", "D"),
+        ("Echo", "E"),
+        ("Hotel", "H"),
+    ]
+)

--- a/internal/slicer/slicer.go
+++ b/internal/slicer/slicer.go
@@ -191,13 +191,13 @@ func Run(options *RunOptions) error {
 
 	// Run mutation scripts. Order is fundamental here as
 	// dependencies must run before dependents.
-	checkWrite := func(path string) error {
+	checkWrite := func(_ *scripts.ContentValue, path string) error {
 		if !pathInfos[path].Mutable {
 			return fmt.Errorf("cannot write file which is not mutable: %s", path)
 		}
 		return nil
 	}
-	checkRead := func(path string) error {
+	checkRead := func(_ *scripts.ContentValue, path string) error {
 		if _, ok := pathInfos[path]; !ok {
 			for globPath := range globbedPaths {
 				if strdist.GlobPath(globPath, path) {
@@ -237,7 +237,7 @@ func Run(options *RunOptions) error {
 				targetPaths = []string{targetPath}
 			}
 			for _, targetPath := range targetPaths {
-				realPath, err := content.RealPath(targetPath, scripts.CheckRead)
+				realPath, err := content.RealPath(targetPath, content.CheckRead)
 				if err == nil {
 					if strings.HasSuffix(targetPath, "/") {
 						untilDirs = append(untilDirs, realPath)


### PR DESCRIPTION
This set of changes makes the following PR possible: https://github.com/canonical/chisel-releases/pull/20 Dotnet packages contain files under `/usr/lib/dotnet/dotnet6-6.0.110`. Package `dotnet-host` creates `/usr/lib/dotnet/dotnet6` symlink via alternatives mechanism. We cannot create this symlink in chisel becase a) we don't have a Starlark functions for creating symlink and b) implicitly created parent directories were not marked as selected. Fix these two issues.

Please do not squash my PRs.